### PR TITLE
Improve local dev + profiles + signup: seed tutors, GET /api/tutors/:id, signup wiring, configurable proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,75 @@
 # tutor-match
-find and list tutoring services by course
+Find and list tutoring services by course
 
-# setting up
-cd into server and client and npm install in both
-cd into server and npm run dev
-another terminal cd into client and run npm dev
+## Dev setup
+
+Prereqs
+- Node.js 18+
+- MongoDB Community (local) or MongoDB Atlas
+
+Install deps
+- Server: `cd server && npm install`
+- Client: `cd client && npm install`
+
+Environment
+- Server env is local-only and gitignored. Create `server/.env`:
+	- Example (local Mongo + custom port):
+		- `PORT=5050`
+		- `MONGODB_URI=mongodb://127.0.0.1:27017/tutor-match`
+		- `JWT_SECRET=dev_local_secret_change_me`
+- Client uses Vite proxy. Create `client/.env` only if your API is NOT on 5000:
+	- `VITE_API_PORT=5050`
+	- If your API runs on 5000 (team default), you can skip `client/.env`.
+
+Run
+1) Start API: `npm -C server run dev`
+2) Start client: `npm -C client run dev` → http://localhost:5173
+
+Seed data (optional)
+- `npm -C server run seed` to insert/update several tutors for demo.
+
+## API
+
+- GET `/api/health` → service status
+- GET `/api/tutors` → list tutors (merged user + profile)
+- GET `/api/tutors/:id` → single tutor by id
+- GET `/api/tutors/sample` → sample tutors (fallback when DB empty)
+- POST `/api/users` → create student/admin: `{ name, email, password, role }`
+- POST `/api/tutors` → create tutor + profile: `{ name, email, password, bio?, hourlyRate?, subjects?, yearsExperience?, location?, onlineOnly? }`
+
+Notes
+- In development, POST `/api/tutors` skips MongoDB transactions so it works with a standalone local MongoDB. In production, transactions are used.
+
+## Frontend
+
+- Tutors list: `/tutors` (uses Vite proxy to call `/api/tutors`)
+- Tutor profile: `/tutor/:id` (calls `/api/tutors/:id`)
+- Sign Up: `/login` → switch to "Sign Up"; supports Student or Tutor creation
+
+## Ports and common issues
+
+- Team default API port is 5000. The client proxy defaults to 5000.
+- If macOS AirPlay Receiver is using 5000 (symptom: 403 Forbidden from AirTunes), either:
+	- Disable AirPlay Receiver (System Settings → AirPlay & Handoff), or
+	- Use a different API port locally (e.g., 5050) and set `client/.env` → `VITE_API_PORT=5050`.
+
+## Postman quick start
+
+POST create tutor (headers: `Content-Type: application/json`):
+```
+POST http://localhost:5050/api/tutors
+{
+	"name": "Taylor Brooks",
+	"email": "taylor.brooks@example.com",
+	"password": "password123",
+	"bio": "CS tutor focused on systems and networks.",
+	"hourlyRate": 42,
+	"subjects": ["Operating Systems", "Networks"],
+	"yearsExperience": 4,
+	"location": "Gainesville, FL",
+	"onlineOnly": false,
+	"avatarUrl": ""
+}
+```
+
+Then open http://localhost:5173/tutors and click into the new tutor profile.

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -26,4 +26,11 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  // Node environment for config files
+  {
+    files: ['vite.config.js'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 ])

--- a/client/src/pages/TutorProfile.jsx
+++ b/client/src/pages/TutorProfile.jsx
@@ -9,15 +9,25 @@ export default function TutorProfile() {
   useEffect(() => {
     const fetchTutor = async () => {
       try {
-        const port = import.meta.env.VITE_PORT || '3001';
-        const response = await fetch(`http://localhost:${port}/api/tutors`);
-        const data = await response.json();
-        
-        // Find the tutor by id from the results
-        const foundTutor = data.results.find((t) => t.id.toString() === id);
-        setTutor(foundTutor || null);
+        const res = await fetch(`/api/tutors/${id}`);
+        if (!res.ok) throw new Error('Failed to load tutor');
+        const data = await res.json();
+        setTutor({
+          id: data.id,
+          name: data.name,
+          email: data.email,
+          bio: data.bio,
+          hourlyRate: data.hourlyRate,
+          courses: data.subjects,
+          rating: data.rating,
+          yearsExperience: data.yearsExperience,
+          avatarUrl: data.avatarUrl,
+          location: data.location,
+          onlineOnly: data.onlineOnly,
+        });
       } catch (err) {
         console.error("Error fetching tutor:", err);
+        setTutor(null);
       } finally {
         setLoading(false);
       }

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,12 +1,19 @@
-import { defineConfig } from 'vite'
+/* eslint-env node */
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': 'http://localhost:5000'
+// Allow overriding API proxy port via VITE_API_PORT in client/.env
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const apiPort = env.VITE_API_PORT || '5000'
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': `http://localhost:${apiPort}`
+      }
     }
   }
 })

--- a/server/index.js
+++ b/server/index.js
@@ -65,6 +65,36 @@ app.get("/api/tutors", async (req, res) => {
   }
 });
 
+// Get a single tutor by id with profile
+app.get("/api/tutors/:id", async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!id) return res.status(400).json({ error: "Missing id" });
+
+    const user = await User.findOne({ _id: id, role: "tutor" }).lean();
+    if (!user) return res.status(404).json({ error: "Tutor not found" });
+
+    const profile = await TutorProfile.findOne({ userId: user._id }).lean();
+
+    return res.json({
+      id: user._id,
+      name: user.name,
+      email: user.email,
+      bio: profile?.bio || "No bio available",
+      hourlyRate: profile?.hourlyRate || 0,
+      subjects: profile?.subjects || [],
+      yearsExperience: profile?.yearsExperience || 0,
+      location: profile?.location,
+      onlineOnly: profile?.onlineOnly ?? true,
+      avatarUrl: user.avatarUrl,
+      rating: 4.5,
+    });
+  } catch (error) {
+    console.error("Error fetching tutor by id:", error);
+    return res.status(500).json({ error: "Failed to fetch tutor" });
+  }
+});
+
 // Fallback: sample tutors if DB is empty
 const sampleTutors = [
   { id: 1, name: "Alex Kim", courses: ["CIS4301", "COP3530"], rating: 4.9 },

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "dev": "nodemon index.js"
+    "dev": "nodemon index.js",
+    "seed": "node scripts/seed.js"
   },
   "keywords": [],
   "author": "",

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -1,0 +1,149 @@
+import dotenv from 'dotenv';
+import { connectDB } from '../config/db.js';
+import User from '../schema/User.js';
+import TutorProfile from '../schema/TutorProfile.js';
+
+dotenv.config();
+
+const tutors = [
+  {
+    name: 'Alex Kim',
+    email: 'alex.kim@example.com',
+    password: 'password123',
+    bio: 'UF CS grad, passionate about data structures and algorithms.',
+    hourlyRate: 40,
+    subjects: ['CIS4301', 'COP3530', 'Data Structures'],
+    yearsExperience: 3,
+    location: 'Gainesville, FL',
+    onlineOnly: false,
+    avatarUrl: ''
+  },
+  {
+    name: 'Priya Patel',
+    email: 'priya.patel@example.com',
+    password: 'password123',
+    bio: 'Math wiz specializing in calculus and statistics.',
+    hourlyRate: 35,
+    subjects: ['MAC2312', 'STA4241', 'Calculus II', 'Stats'],
+    yearsExperience: 4,
+    location: 'Remote',
+    onlineOnly: true,
+    avatarUrl: ''
+  },
+  {
+    name: 'Diego Lopez',
+    email: 'diego.lopez@example.com',
+    password: 'password123',
+    bio: 'AI/ML enthusiast with hands-on projects in Python.',
+    hourlyRate: 45,
+    subjects: ['CAP4641', 'CEN3031', 'Machine Learning'],
+    yearsExperience: 5,
+    location: 'Gainesville, FL',
+    onlineOnly: false,
+    avatarUrl: ''
+  },
+  {
+    name: 'Sara Nguyen',
+    email: 'sara.nguyen@example.com',
+    password: 'password123',
+    bio: 'Physics and linear algebra tutor with a practical approach.',
+    hourlyRate: 38,
+    subjects: ['PHY2048', 'Linear Algebra'],
+    yearsExperience: 2,
+    location: 'Remote',
+    onlineOnly: true,
+    avatarUrl: ''
+  },
+  {
+    name: 'Marcus Lee',
+    email: 'marcus.lee@example.com',
+    password: 'password123',
+    bio: 'Full-stack dev mentor for web technologies.',
+    hourlyRate: 50,
+    subjects: ['Web Dev', 'React', 'Node.js'],
+    yearsExperience: 6,
+    location: 'Gainesville, FL',
+    onlineOnly: false,
+    avatarUrl: ''
+  }
+];
+
+function hashPassword(pw) {
+  // Keep consistent with server logic (simple base64 for demo)
+  return Buffer.from(pw).toString('base64');
+}
+
+async function upsertTutor(tutor) {
+  const existingUser = await User.findOne({ email: tutor.email });
+
+  if (existingUser) {
+    // Update existing tutor user and profile
+    await User.updateOne(
+      { _id: existingUser._id },
+      { $set: { name: tutor.name, avatarUrl: tutor.avatarUrl, skills: tutor.subjects, role: 'tutor' } }
+    );
+
+    await TutorProfile.updateOne(
+      { userId: existingUser._id },
+      {
+        $set: {
+          bio: tutor.bio,
+          hourlyRate: tutor.hourlyRate,
+          subjects: tutor.subjects,
+          yearsExperience: tutor.yearsExperience,
+          location: tutor.location,
+          onlineOnly: tutor.onlineOnly,
+        }
+      },
+      { upsert: true }
+    );
+
+    console.log(`Updated tutor: ${tutor.name} (${tutor.email})`);
+    return { action: 'updated', email: tutor.email };
+  }
+
+  // Create new user + tutor profile (no transaction on standalone)
+  const user = await User.create({
+    role: 'tutor',
+    email: tutor.email,
+    passwordHash: hashPassword(tutor.password),
+    name: tutor.name,
+    avatarUrl: tutor.avatarUrl,
+    skills: tutor.subjects,
+  });
+
+  await TutorProfile.create({
+    userId: user._id,
+    bio: tutor.bio,
+    hourlyRate: tutor.hourlyRate,
+    subjects: tutor.subjects,
+    yearsExperience: tutor.yearsExperience,
+    location: tutor.location,
+    onlineOnly: tutor.onlineOnly,
+  });
+
+  console.log(`Inserted tutor: ${tutor.name} (${tutor.email})`);
+  return { action: 'inserted', email: tutor.email };
+}
+
+async function run() {
+  try {
+    await connectDB();
+    let inserted = 0, updated = 0, failed = 0;
+    for (const t of tutors) {
+      try {
+        const res = await upsertTutor(t);
+        if (res.action === 'inserted') inserted += 1; else updated += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+    console.log(`\nSeed complete → inserted: ${inserted}, updated: ${updated}, failed: ${failed}`);
+    process.exit(0);
+  } catch (err) {
+    console.error('Seed failed:', err);
+    process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION

Summary:
- Seed the database with tutors for demo data
- Add tutor profile endpoint and wire the profile page
- Implement Sign Up (student/tutor) on the client
- Make the API proxy port configurable to avoid local port conflicts

What changed:
- server/index.js
  - Added GET /api/tutors/:id to return a single tutor merged with their profile
  - POST /api/tutors uses transactions only in production; in development it creates user and profile without transactions so it works with standalone local MongoDB
- server/package.json
  - Added "seed": "node scripts/seed.js"
- server/scripts/seed.js
  - New script to insert or update multiple tutors (idempotent by email)
- client/src/pages/Tutors.jsx
  - Uses relative /api fetch (via Vite proxy) and falls back to /api/tutors/sample when DB is empty or unavailable
- client/src/pages/TutorProfile.jsx
  - Fetches a single tutor via /api/tutors/:id and maps fields to the UI
- client/src/pages/Login.jsx
  - Sign Up flow:
    - Student/Admin → POST /api/users
    - Tutor → POST /api/tutors (supports bio, hourlyRate, subjects, yearsExperience, location, onlineOnly)
  - Shows loading and error messages; redirects on success (Tutor → /tutor/{id}, Student/Admin → /tutors)
- client/vite.config.js
  - Proxy /api to http://localhost:${VITE_API_PORT || 5000}
- client/eslint.config.js
  - Marks vite.config.js as Node environment
- README.md
  - Expanded setup, env/ports, seed, endpoints, and Postman steps

Why:
- Local MongoDB typically is not a replica set, so transactions fail by default. Development path skips transactions while keeping production transactional.
- macOS AirPlay can occupy port 5000. The proxy now supports a local override (VITE_API_PORT) so each dev can run their own port without code changes.
- Seed and profile endpoint make the app demo-ready and support end-to-end navigation.

How to test:
1) Environment (local only, both files are gitignored):
   - server/.env:
     - PORT=5050
     - MONGODB_URI=mongodb://127.0.0.1:27017/tutor-match
   - client/.env (only if API is not on 5000):
     - VITE_API_PORT=5050
2) Seed:
   - npm -C server run seed
3) Run:
   - API: npm -C server run dev (http://localhost:5050)
   - Client: npm -C client run dev (http://localhost:5173)
4) Verify:
   - http://localhost:5173/tutors shows seeded tutors
   - Click a tutor to open /tutor/:id with full details
   - Sign Up at /login (switch to Sign Up, choose Student or Tutor) and verify redirect:
     - Tutor → /tutor/{id}
     - Student/Admin → /tutors

Ports and env notes:
- Team default API port is 5000 (no client/.env needed).
- If 5000 is blocked locally (macOS AirPlay), run API on 5050 and set client/.env → VITE_API_PORT=5050.

Risks:
- Development-only behavior: POST /api/tutors skips transactions; production remains transactional.
- No breaking API surface changes.

Follow-ups:
- Implement login (bcrypt + JWT) and /api/auth/me
- Add a simple Create Tutor page (UI) to avoid Postman dependency
- Add input validation and tests for tutor endpoints

Branch:
feature/db-seed-and-tutors-fallback